### PR TITLE
Add test cleanup fixtures 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,22 @@
+import shutil
+from pathlib import Path
+
 import numpy as np
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def cleanup_test_outputs():
+    """Clean up output directories created during tests."""
+    yield
+    for pattern in ["output_pywake_*", "output_test_*"]:
+        for path in Path(".").glob(pattern):
+            if path.is_dir():
+                shutil.rmtree(path)
+    output = Path("output")
+    if output.is_dir():
+        shutil.rmtree(output)
+
 
 # DTU 10MW turbine data
 # (from examples/cases/windio_4turbines/plant_energy_turbine/DTU_10MW_turbine.yaml)


### PR DESCRIPTION
## Summary

Closes #41 

- Add a single autouse pytest fixture for automatic test output cleanup

## Problem

Tests were leaving behind output directories (`output_pywake_4wts/`, `output_test_foxes/`, `output/`, etc.) that accumulated over multiple runs.

## Solution

Added a single `autouse=True` fixture in `tests/conftest.py` that cleans up output directories after each test. Since it's autouse, no test signatures need to change — tests stay exactly as they were.

## Changes

| File | Change |
|------|--------|
| `tests/conftest.py` | Add `cleanup_test_outputs` autouse fixture (~12 lines) |

No changes to test files, production code, or YAML configs.

## Test plan

- [x] `uv run pytest tests/test_pywake.py -v` — all 11 tests pass
- [x] `ls output* 2>/dev/null` after test run — no output directories remain
- [x] `git diff fix/ci-failures -- wifa/ examples/` — empty (no production changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)