### PR TITLE
Fix validate_yaml double extension and string time coordinates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "floris @ git+https://github.com/lejeunemax/floris.git",
     "wayve @ git+https://gitlab.kuleuven.be/TFSO-software/wayve",
     "numpy>=1.22,<3.0",
-    "xarray>=2022.0.0,<2025",
+    "xarray",
     "mpmath",
 ]
 

--- a/wifa/main_api.py
+++ b/wifa/main_api.py
@@ -17,7 +17,7 @@ sys.path.append(windIO.__path__[0])
 
 def run_api(yaml_input):
     # validate input
-    validate_yaml(yaml_input, windIO.__path__[0] + "/plant/wind_energy_system.yaml")
+    validate_yaml(yaml_input, "plant/wind_energy_system")
 
     # get number of turbines
     if isinstance(yaml_input, dict):

--- a/wifa/pywake_api.py
+++ b/wifa/pywake_api.py
@@ -215,6 +215,10 @@ def dict_to_site(resource_dict):
         if name in resource_ds:
             resource_ds = resource_ds.rename({name: rename_map[name]})
 
+    if "time" in resource_ds.dims:
+        # Convert time coordinate to integer indices for GridInterpolator compatibility
+        # (string or datetime time coords cannot be interpolated numerically)
+        resource_ds = resource_ds.assign_coords(time=np.arange(len(resource_ds.time)))
     if "P" not in resource_ds and "time" in resource_ds.dims:
         n_time = len(resource_ds.time)
         # Create uniform probability array (1/N)


### PR DESCRIPTION
## Summary
- Fix `validate_yaml` call in `run_api()` to pass schema key `"plant/wind_energy_system"` instead of constructing a full file path, which caused a `.yaml.yaml` double extension error
- Convert string/datetime time coordinates to integer indices in `dict_to_site()` so PyWake's `GridInterpolator` can interpolate numerically
- Relax xarray version constraint (remove `<2025` upper bound)

🤖 Generated with [Claude Code](https://claude.com/claude-code)