### PR TITLE
Eliminate redundant YAML+netCDF loads in run_api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WIFA (Wind Farm API)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10-3.12](https://img.shields.io/badge/python-3.10--3.12-blue.svg)](https://www.python.org/downloads/)
 [![Documentation](https://img.shields.io/badge/docs-online-green.svg)](https://euflow.github.io/WIFA/)
 
 WIFA is an open-source multi-fidelity wind farm simulation framework that provides a unified interface to multiple flow modeling tools.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -4,7 +4,7 @@ Install
 Prerequisites
 ~~~~~~~~~~~~~
 
-WIFA requires Python 3.9-3.11. We recommend using `uv <https://docs.astral.sh/uv/>`_ for fast, reliable Python environment management.
+WIFA requires Python 3.10-3.12. We recommend using `uv <https://docs.astral.sh/uv/>`_ for fast, reliable Python environment management.
 
 **Install uv:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 requires-python = ">=3.10,<3.13"
 dependencies = [
     "windIO @ git+https://github.com/EUFlow/windIO.git",
-    "xarray>=2022.0.0,<2025",
+    "xarray",
     "scipy",
     "pyyaml",
 ]

--- a/wifa/main_api.py
+++ b/wifa/main_api.py
@@ -3,7 +3,6 @@ import os
 import sys
 
 import windIO
-from windIO import load_yaml
 from windIO import validate as validate_yaml
 
 from .cs_api.cs_modules.csLaunch.cs_run_function import run_code_saturne
@@ -16,40 +15,33 @@ sys.path.append(windIO.__path__[0])
 
 
 def run_api(yaml_input):
-    # validate input
-    validate_yaml(yaml_input, windIO.__path__[0] + "/plant/wind_energy_system.yaml")
-
-    # get number of turbines
     if isinstance(yaml_input, dict):
         yaml_dat = yaml_input
     else:
-        yaml_dat = load_yaml(yaml_input)
+        yaml_dat = validate_yaml(yaml_input, "plant/wind_energy_system")
 
     model_name = yaml_dat["attributes"]["flow_model"]["name"]
 
     if model_name.lower() == "pywake":
-        pywake_aep = run_pywake(yaml_input)
+        run_pywake(yaml_dat)
 
     elif model_name.lower() == "foxes":
-        foxes_aep = run_foxes(yaml_input)
+        run_foxes(yaml_dat)
 
     elif model_name.lower() == "floris":
-        floris_aep = run_floris(yaml_input)
+        run_floris(yaml_dat)
 
     elif model_name.lower() == "wayve":
-        # Output directory
-        # yaml_input_no_ext = os.path.splitext(yaml_input)[0]  # Remove the file extension
-        # output_dir_name = 'output_wayve' + yaml_input_no_ext.replace(os.sep, '_')  # Replace directory separators
         output_dir_name = yaml_dat["attributes"]["model_outputs_specification"][
             "output_folder"
         ]
         if not os.path.exists(output_dir_name):
             os.makedirs(output_dir_name)
 
-        run_wayve(yaml_input, output_dir_name)
+        run_wayve(yaml_dat, output_dir_name)
 
     elif model_name.lower() == "codesaturne":
-        run_code_saturne(yaml_input, test_mode=True)
+        run_code_saturne(yaml_dat, test_mode=True)
 
     else:
         print("Invalid Model")

--- a/wifa/pywake_api.py
+++ b/wifa/pywake_api.py
@@ -217,6 +217,10 @@ def dict_to_site(resource_dict):
         if name in resource_ds:
             resource_ds = resource_ds.rename({name: rename_map[name]})
 
+    if "time" in resource_ds.dims:
+        # Convert time coordinate to integer indices for GridInterpolator compatibility
+        # (string or datetime time coords cannot be interpolated numerically)
+        resource_ds = resource_ds.assign_coords(time=np.arange(len(resource_ds.time)))
     if "P" not in resource_ds and "time" in resource_ds.dims:
         n_time = len(resource_ds.time)
         # Create uniform probability array (1/N)


### PR DESCRIPTION
## Summary
- `run_api()` was loading the full YAML+netCDF **4 times** per simulation (validate → discard, load_yaml, then downstream runner validates + loads again). Now it loads once via `validate_yaml()` (which returns the loaded dict) and passes the dict to model runners, which skip their internal validate+load when receiving a dict.
- Reduces transient memory load

Depends on #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)