### PR TITLE
Support circle-based site boundaries in pywake

### DIFF
--- a/tests/test_pywake.py
+++ b/tests/test_pywake.py
@@ -466,6 +466,40 @@ def test_pywake_dict_timeseries_per_turbine_with_density(tmp_path):
     assert aep_with != aep_without
 
 
+def test_site_bounds_circle_and_polygons():
+    from wifa.pywake_api import _site_bounds
+
+    # Circle: bounding box is center +/- radius
+    assert _site_bounds(
+        {"circle": {"center": {"x": 100.0, "y": -50.0}, "radius": 500.0}}
+    ) == (-400.0, 600.0, -550.0, 450.0)
+
+    # Polygons: bounding box spans all polygons, not just the first
+    assert _site_bounds(
+        {
+            "polygons": [
+                {"x": [0, 10], "y": [0, 10]},
+                {"x": [-5, 3], "y": [2, 20]},
+            ]
+        }
+    ) == (-5, 10, 0, 20)
+
+    with pytest.raises(ValueError, match="polygons.*or.*circle"):
+        _site_bounds({})
+
+
+def test_pywake_circle_boundaries(tmp_path):
+    """Circle-based site boundaries run through pywake (GH issue #26)."""
+    from conftest import make_timeseries_per_turbine_system_dict
+
+    system_dict = make_timeseries_per_turbine_system_dict("pywake")
+    system_dict["site"]["boundaries"] = {
+        "circle": {"center": {"x": 1250.0, "y": 0.0}, "radius": 1500.0}
+    }
+    aep = run_pywake(system_dict, output_dir=str(tmp_path))
+    assert np.isfinite(aep) and aep > 0
+
+
 # if __name__ == "__main__":
 #    test_heterogeneous_wind_rose()
 #     simple_yaml_to_pywake('../examples/cases/windio_4turbines_multipleTurbines/plant_energy_turbine/IEA_10MW_turbine.yaml')

--- a/wifa/pywake_api.py
+++ b/wifa/pywake_api.py
@@ -254,6 +254,31 @@ def get_flow_field_param(system_dat, param_name, default=None):
         return default
 
 
+def _site_bounds(boundaries):
+    """Bounding box (xlb, xub, ylb, yub) of the windIO site boundaries.
+
+    Supports both boundary types of the windIO site schema: a group of
+    polygons, or a circle with center and radius.
+    """
+    if "polygons" in boundaries:
+        xs = np.concatenate([np.atleast_1d(p["x"]) for p in boundaries["polygons"]])
+        ys = np.concatenate([np.atleast_1d(p["y"]) for p in boundaries["polygons"]])
+        return np.min(xs), np.max(xs), np.min(ys), np.max(ys)
+    if "circle" in boundaries:
+        center = boundaries["circle"]["center"]
+        radius = boundaries["circle"]["radius"]
+        return (
+            center["x"] - radius,
+            center["x"] + radius,
+            center["y"] - radius,
+            center["y"] + radius,
+        )
+    raise ValueError(
+        "Site boundaries must define either 'polygons' or 'circle', "
+        f"got: {list(boundaries)}"
+    )
+
+
 def construct_site(system_dat, resource_dat, hub_heights, x_positions):
     """Construct site object and wind conditions for simulation.
 
@@ -272,11 +297,7 @@ def construct_site(system_dat, resource_dat, hub_heights, x_positions):
     from windIO import dict_to_netcdf
 
     # Get flow field bounds from config or site boundaries
-    boundaries = system_dat["site"]["boundaries"]["polygons"][0]
-    WFXLB = np.min(boundaries["x"])
-    WFXUB = np.max(boundaries["x"])
-    WFYLB = np.min(boundaries["y"])
-    WFYUB = np.max(boundaries["y"])
+    WFXLB, WFXUB, WFYLB, WFYUB = _site_bounds(system_dat["site"]["boundaries"])
 
     # Override with explicit flow field bounds if specified
     WFXLB = get_flow_field_param(system_dat, "xlb", WFXLB)


### PR DESCRIPTION
`construct_site` assumed `boundaries.polygons` and raised `KeyError` for the windIO `circle` boundary type.

- New `_site_bounds` helper derives flow-field bounds from either boundary type: polygon bounding box, or circle center ± radius.
- Polygon bounds now span all polygons instead of only the first.
- Unit test for `_site_bounds` + end-to-end pywake run with circle boundaries.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)